### PR TITLE
Markdown change + shorten url added

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
- Custom update channel URL:
+ ### Custom update channel URL:
  
  https://raw.githubusercontent.com/kantjer/MagiskFiles/master/updates/kantjer.json
+
+
+### Shorten URL:
+
+https://goo.gl/3ws6NC


### PR DESCRIPTION
Shorten URL added in case you want to insert the URL manually via Magisk Manager.